### PR TITLE
Fix helm chart push

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install requirements
-        run: sudo bash $(pwd)/scripts/requirements.sh
+        run: bash $(pwd)/scripts/requirements.sh
 
       - name: Log into registry
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install requirements
-        run: sudo bash $(pwd)/scripts/requirements.sh
+        run: bash $(pwd)/scripts/requirements.sh
 
       - name: Test brudi-operator chart
         run: >

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install requirements
-        run: sudo bash $(pwd)/scripts/requirements.sh
+        run: bash $(pwd)/scripts/requirements.sh
 
       - name: Log into registry
         run: |

--- a/scripts/requirements.sh
+++ b/scripts/requirements.sh
@@ -5,18 +5,18 @@ set -e
 GENERIC_BIN_DIR="/usr/local/bin"
 
 ## Generic stuff
-apt-get -qq update
-apt-get -qq install curl wget
+sudo apt-get -qq update
+sudo apt-get -qq install curl wget git
 
 ## Install Operator-SDK
 if [[ ! -x "$(command -v operator-sdk)" ]]; then
     OPERATOR_SDK_VERSION="0.15.2"
     OPERATOR_SDK_BIN="${GENERIC_BIN_DIR}/operator-sdk"
 
-    wget -q \
+    sudo wget -q \
         "https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk-v${OPERATOR_SDK_VERSION}-x86_64-linux-gnu" \
         -O "${OPERATOR_SDK_BIN}"
-    chmod +x "${OPERATOR_SDK_BIN}"
+    sudo chmod +x "${OPERATOR_SDK_BIN}"
 fi
 
 ## Install Helm
@@ -25,7 +25,7 @@ if [[ ! -x "$(command -v helm)" ]]; then
     HELM_BIN="${GENERIC_BIN_DIR}/helm"
 
     curl -sS -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-    chmod +x ${HELM_BIN}
+    sudo chmod +x ${HELM_BIN}
 fi
 
 ## Install Helm push
@@ -33,5 +33,5 @@ helm plugin install https://github.com/chartmuseum/helm-push.git
 
 ## Install Docker-CE
 if [[ ! -x "$(command -v docker)" ]]; then
-    curl -sS -L https://get.docker.com/ | bash
+    curl -sS -L https://get.docker.com/ | sudo bash
 fi


### PR DESCRIPTION
Github uses the same home directory for users `runner` and `root`. WHY??!
Installing a helm plugin with sudo as root creates files and directories (`/home/runner/.cache/helm/`) in the home directory.
Later, helm is running as a normal user and not able to write files in there directories.

Adding a new repository failes with 
`Error: looks like "https://helm.mittwald.de" is not a valid chart repository or cannot be reached: open /home/runner/.cache/helm/repository/mittwald-index.yaml: no such file or directory`